### PR TITLE
Fix bug with efi volume, add distributive label

### DIFF
--- a/usr/bin/uefiboot-update
+++ b/usr/bin/uefiboot-update
@@ -4,6 +4,9 @@ ROOT=""
 OPTIONS="ro quiet"
 ROOTFLAGS=""
 K_SUFFIX=""
+DUSTRIB=$(lsb_release -d -s)
+DUSTRIB_ID=$(echo $DUSTRIB | cut -d' ' -f1)
+EFI_VOLUME=$(blkid -lt TYPE="vfat" -o device)
 
 # Read the config file if it exists
 if [ -e /etc/uefiboot.conf ]
@@ -27,7 +30,7 @@ then
 fi
 
 # Remove all Ubuntu boot options from UEFI.
-for OPT in $(efibootmgr | sed '/Boot[0-9].*buntu/!d;s/Boot//;s/\*.*//')
+for OPT in $(efibootmgr | sed "/Boot[0-9].*$DUSTRIB_ID/!d;s/Boot//;s/\*.*//")
 do
   efibootmgr -Bb$OPT >/dev/null
 done
@@ -39,6 +42,6 @@ echo "Updating UEFI boot options"
 for KVER in $(ls /boot/vmlinuz*generic | sed 's/\/boot\/vmlinuz-//' | sort)
 do
   echo -n "Kernel vmlinuz-$KVER found"
-  efibootmgr -cl vmlinuz-$KVER$K_SUFFIX -L "Ubuntu-"$KVER -u "root=$ROOT $ROOTFLAGS $OPTIONS initrd=initrd.img-$KVER" >/dev/null
+  efibootmgr --create --disk $(expr "$EFI_VOLUME" : '\([^0-9]*\)') --part $(expr "$EFI_VOLUME" : '.*\([0-9]\)') --loader vmlinuz-$KVER$K_SUFFIX --label "$DUSTRIB" -u "root=$ROOT $ROOTFLAGS $OPTIONS initrd=initrd.img-$KVER" >/dev/null
   echo " ... added"
 done


### PR DESCRIPTION
1) If efi partition isn't the first, the boot path isn't correct. I get first vfat volume and parsing for disk and part . Disk and part adding in efibootmgr parameters.

2)I add  commands for insert distributive name in parameter label. 

I hope it will be useful.